### PR TITLE
Define private _properties as an instance variable.

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -37,11 +37,68 @@
     XMLHttpRequestEventTarget.call(this);
     options = options || {};
     this._flag.anonymous = !!options.anon;
-    Object.defineProperty(this, 'upload', {
-      configurable: true,
-      enumerable: true,
-      value: new XMLHttpRequestUpload(),
-      writable: false
+    Object.defineProperties(this, {
+      upload: {
+        configurable: true,
+        enumerable: true,
+        value: new XMLHttpRequestUpload(),
+        writable: false
+      },
+      _properties: {
+        configurable: false,
+        enumerable: false,
+        value: Object.create(Object.prototype, {
+          auth: {
+            configurable: false,
+            enumerable: true,
+            value: '',
+            writable: true
+          },
+          client: {
+            configurable: false,
+            enumerable: true,
+            value: null,
+            writable: true,
+          },
+          method: {
+            configurable: false,
+            enumerable: true,
+            value: undefined,
+            writable: true
+          },
+          responseHeaders: {
+            configurable: false,
+            enumerable: true,
+            value: {},
+            writable: true,
+          },
+          responseBuffer: {
+            configurable: false,
+            enumerable: true,
+            value: null,
+            writable: true,
+          },
+          responseType: {
+            configurable: false,
+            enumerable: true,
+            value: '',
+            writable: true,
+          },
+          requestHeaders: {
+            configurable: false,
+            enumerable: true,
+            value: {},
+            writable: true,
+          },
+          uri: {
+            configurable: true,
+            enumerable: true,
+            value: '',
+            writable: true
+          }
+        }),
+        writable: false
+      }
     });
   }
 
@@ -134,61 +191,6 @@
           });
           return flag;
         }
-      },
-      _properties: {
-        configurable: false,
-        enumerable: false,
-        value: Object.create(Object.prototype, {
-          auth: {
-            configurable: false,
-            enumerable: true,
-            value: '',
-            writable: true
-          },
-          client: {
-            configurable: false,
-            enumerable: true,
-            value: null,
-            writable: true,
-          },
-          method: {
-            configurable: false,
-            enumerable: true,
-            value: undefined,
-            writable: true
-          },
-          responseHeaders: {
-            configurable: false,
-            enumerable: true,
-            value: {},
-            writable: true,
-          },
-          responseBuffer: {
-            configurable: false,
-            enumerable: true,
-            value: null,
-            writable: true,
-          },
-          responseType: {
-            configurable: false,
-            enumerable: true,
-            value: '',
-            writable: true,
-          },
-          requestHeaders: {
-            configurable: false,
-            enumerable: true,
-            value: {},
-            writable: true,
-          },
-          uri: {
-            configurable: true,
-            enumerable: true,
-            value: '',
-            writable: true
-          }
-        }),
-        writable: false
       },
       readyState: {
         configurable: true,


### PR DESCRIPTION
When _properties are defined only in XMLHttpRequest.prototype, bad
things happen when one uses several instances of XMLHttpRequest in
parallel. (For example this._properties.responseBuffer points to the
same buffer in all instances.)
