### PR TITLE
Call onreadystatechange every time a chunk of data is received.

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -333,6 +333,7 @@
         }
         chunk.copy(this._properties.responseBuffer, byteOffset);
         byteOffset += chunk.length;
+        _readyStateChange.call(this, XMLHttpRequest.LOADING);
       }.bind(this));
       response.addListener('end', function() {
         _readyStateChange.call(this, XMLHttpRequest.DONE);


### PR DESCRIPTION
HTTP Streaming clients (such as SockJS xhr-streaming transport) depend
on onreadystatechange handler being invoked in readyState=3 (LOADING)
whenever a new chunk of data is available.
