### PR TITLE
Partial support for synchronous requests using optional http-sync dep

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,10 +29,11 @@
   var utils = {};
 
   utils.createClient = (function() {
-    function createClient(options, async, callback) {
+    function createClient(options, sync, callback) {
       var client;
       options = optionsParse(options || {});
-      client = new http.ClientRequest(options, callback);
+      if (sync) client = require('http-sync').request(options);
+      else client = new http.ClientRequest(options, callback);
       return client;
     }
 

--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -322,25 +322,31 @@
         }
       });
       _properties.responseHeaders = response.headers;
-      contentLength = response.headers['content-length'] || contentLength;
-      bufferLength = parseInt(contentLength, 10);
-      _properties.responseBuffer = new Buffer(bufferLength);
-      _readyStateChange.call(this, XMLHttpRequest.LOADING);
-      response.addListener('data', function(chunk) {
-        var buffer;
-        if (bufferLength === 0) {
-          buffer = this._properties.responseBuffer;
-          this._properties.responseBuffer = new Buffer(buffer.length + chunk.length);
-          buffer.copy(this._properties.responseBuffer);
-        }
-        chunk.copy(this._properties.responseBuffer, byteOffset);
-        byteOffset += chunk.length;
-        _readyStateChange.call(this, XMLHttpRequest.LOADING);
-      }.bind(this));
-      response.addListener('end', function() {
+      if (response.body != null) {
+        _properties.responseBuffer = response.body;
         _readyStateChange.call(this, XMLHttpRequest.DONE);
-        _properties.client = null;
-      }.bind(this));
+          _properties.client = null;
+      } else {
+        bufferLength = parseInt(contentLength, 10);
+        contentLength = response.headers['content-length'] || contentLength;
+        _properties.responseBuffer = new Buffer(bufferLength);
+        _readyStateChange.call(this, XMLHttpRequest.LOADING);
+        response.addListener('data', function(chunk) {
+          var buffer;
+          if (bufferLength === 0) {
+            buffer = this._properties.responseBuffer;
+            this._properties.responseBuffer = new Buffer(buffer.length + chunk.length);
+            buffer.copy(this._properties.responseBuffer);
+          }
+          chunk.copy(this._properties.responseBuffer, byteOffset);
+          byteOffset += chunk.length;
+          _readyStateChange.call(this, XMLHttpRequest.LOADING);
+        }.bind(this));
+        response.addListener('end', function() {
+          _readyStateChange.call(this, XMLHttpRequest.DONE);
+          _properties.client = null;
+        }.bind(this));
+      }
     }
 
     function _setDispatchProgressEvents(stream) {
@@ -396,7 +402,8 @@
       }
       this._properties.method = method;
       this._properties.uri = uri;
-      this._flag.synchronous = !!async;
+      if (async === undefined) async = true;
+      this._flag.synchronous = !async;
       if (argumentCount >= 4) {
         this._properties.auth = [
           user || '',
@@ -413,12 +420,12 @@
     proto.send = function send(body) {
       var _properties = this._properties;
       var client;
-      var async;
+      var sync;
       if (this.readyState !== XMLHttpRequest.OPENED) {
         throw new Error(); // todo
       }
-      async = this._flag.synchronous;
-      client = utils.createClient(this._properties, async, function() {
+      sync = this._flag.synchronous;
+      client = utils.createClient(this._properties, sync, function() {
         _setDispatchProgressEvents.apply(this, arguments);
         _receiveResponse.apply(this, arguments);
       }.bind(this));
@@ -432,7 +439,10 @@
         client.on('socket', _setDispatchProgressEvents.bind(this.upload));
         client.write(body);
       }
-      client.end();
+      var ret = client.end();
+      if (sync) {
+        _receiveResponse.call(this, ret);
+      }
     };
 
     proto.setRequestHeader = function setRequestHeader(header, value) {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~1.13.0"
+    "mocha": "~1.13.0",
+    "http-sync": "^0.0.5"
   },
-  "optionalDependencies": {},
+  "optionalDependencies": {
+    "http-sync": "^0.0.5"
+  },
   "engines": {
     "node": "*"
   }

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,35 @@
+
+var assert = require('assert');
+var http = require('http');
+var url = require('url');
+
+
+function parseQueryString(uri) {
+  var urlObj = url.parse(uri, true);
+  return urlObj.query;
+}
+
+function receiveRequest(req, res) {
+  var query = parseQueryString(req.url);
+  var body = query.body || '';
+  res.writeHead(+(query.status || 200), {
+    'Content-Type': 'text/plain'
+  });
+  res.write(body);
+  res.end();
+}
+
+var server = http.createServer();
+server.on('request', receiveRequest);
+
+var port = 10000;
+
+(function retry(port) {
+  try {
+    server.listen(port, function() {
+      process.send({ baseUri: 'http://127.0.0.1:' + port });
+    });
+  } catch (e) {
+    retry(port + 1);
+  }
+})(port);


### PR DESCRIPTION
This depends on acceptance of https://github.com/dhruvbird/http-sync/pull/30.
That's why it depends on next version of http-sync.
Renamed async -> sync param to make code more readable.
Testing is done through forked server - or else the synchronous test just hangs (expectedly).