### PR TITLE
Per specs, forbid some request headers to be set

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -24,6 +24,8 @@
 
   var HTTP_STATUS_CODES = require('http').STATUS_CODES;
 
+  var forbiddenRequestHeaders = new RegExp('^(' + ["Accept-Charset", "Accept-Encoding", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Connection", "Content-Length", "Cookie", "Cookie2", "Date", "DNT", "Expect", "Host", "Keep-Alive", "Origin", "Referer", "TE", "Trailer", "Transfer-Encoding", "Upgrade", "User-Agent", "Via", "Sec-.*", "Proxy-.*"].join('|') + ')$');
+
   var Event = require('./event');
   var ProgressEvent = require('./progressevent');
   var XMLHttpRequestEventTarget = require('./xmlhttprequesteventtarget');
@@ -439,6 +441,7 @@
       if (this.readyState === XMLHttpRequest.UNSENT) {
         throw new Error(''); // todo  
       }
+      if (forbiddenRequestHeaders.test(header)) return;
       this._properties.requestHeaders[header] = value;
     };
   })(XMLHttpRequest.prototype);


### PR DESCRIPTION
http://xhr.spec.whatwg.org/#the-setrequestheader()-method
http://fetch.spec.whatwg.org/#forbidden-header-name

This calls for proper cookie support !
