### PR TITLE
Set cookie request header for same origin window.document.cookie

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -413,13 +413,18 @@
 
     proto.send = function send(body) {
       var _properties = this._properties;
+      var document = this.window && this.window.document;
+      var parsedUri = URL.parse(_properties.uri);
+      if (parsedUri.host == null && document && document.location != null) {
+        _properties.uri = URL.resolve(document.location.toString(), _properties.uri);
+      }
       var client;
       var async;
       if (this.readyState !== XMLHttpRequest.OPENED) {
         throw new Error(); // todo
       }
       async = this._flag.synchronous;
-      client = utils.createClient(this._properties, async, function() {
+      client = utils.createClient(_properties, async, function() {
         _setDispatchProgressEvents.apply(this, arguments);
         _receiveResponse.apply(this, arguments);
       }.bind(this));
@@ -432,7 +437,7 @@
       var document = this.window && this.window.document;
       if (document && document.cookie) {
         // this is stricter cross-origin policy than 'same parent' cookie policy
-        if (URL.parse(_properties.uri).hostname == document.location.hostname) {
+        if (parsedUri.hostname == document.location.hostname) {
           client.setHeader('Cookie', document.cookie);
         }
       }

--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -19,6 +19,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
+function getDoc() {
+  return global.window && global.window.document;
+}
+
 (function(global) {
   'use strict';
 
@@ -29,6 +34,7 @@
   var XMLHttpRequestEventTarget = require('./xmlhttprequesteventtarget');
   var XMLHttpRequestUpload = require('./xmlhttprequestupload');
   var utils = require('./utils');
+  var URL = require('url');
 
   function XMLHttpRequest(options) {
     if (!(this instanceof XMLHttpRequest)) {
@@ -427,6 +433,14 @@
         var value = _properties.requestHeaders[key];
         client.setHeader(key, value);
       });
+
+      var document = getDoc();
+      if (document && document.cookie) {
+        // this is stricter cross-origin policy than 'same parent' cookie policy
+        if (URL.parse(_properties.uri).hostname == document.location.hostname) {
+          client.setHeader('Cookie', document.cookie);
+        }
+      }
       _readyStateChange.call(this, XMLHttpRequest.HEADERS_RECEIVED);
       if (body) {
         client.on('socket', _setDispatchProgressEvents.bind(this.upload));

--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -19,11 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-function getDoc() {
-  return global.window && global.window.document;
-}
-
 (function(global) {
   'use strict';
 
@@ -434,7 +429,7 @@ function getDoc() {
         client.setHeader(key, value);
       });
 
-      var document = getDoc();
+      var document = this.window && this.window.document;
       if (document && document.cookie) {
         // this is stricter cross-origin policy than 'same parent' cookie policy
         if (URL.parse(_properties.uri).hostname == document.location.hostname) {


### PR DESCRIPTION
The window object is set as property on the XMLHttpRequest instance after creation.
see https://github.com/kapouer/jsdom/blob/w3c-xmlhttprequest/lib/jsdom/browser/index.js#L232

Later commits add support for URL resolution relative to window.document.location.