### PR TITLE
fix/hack to send progress datas total, loaded and lengthComputable

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -324,8 +324,15 @@
       _properties.responseHeaders = response.headers;
       contentLength = response.headers['content-length'] || contentLength;
       bufferLength = parseInt(contentLength, 10);
+      this.lengthComputable = false;
+      if(bufferLength !== 0){
+        this.total = bufferLength;
+        this.loaded = 0;
+        this.lengthComputable = true;
+      }
       _properties.responseBuffer = new Buffer(bufferLength);
       _readyStateChange.call(this, XMLHttpRequest.LOADING);
+      var that = this;
       response.addListener('data', function(chunk) {
         var buffer;
         if (bufferLength === 0) {
@@ -335,6 +342,7 @@
         }
         chunk.copy(this._properties.responseBuffer, byteOffset);
         byteOffset += chunk.length;
+        that.loaded = byteOffset;
         _readyStateChange.call(this, XMLHttpRequest.LOADING);
       }.bind(this));
       response.addListener('end', function() {
@@ -347,7 +355,8 @@
       var loadStartEvent = new ProgressEvent('loadstart');
       this.dispatchEvent(loadStartEvent);
       stream.on('data', function() {
-        var progressEvent = new ProgressEvent('progress');
+        var progress = {lengthComputable: this.lengthComputable, total: this.total, loaded: this.loaded};
+        var progressEvent = new ProgressEvent('progress', progress);
         this.dispatchEvent(progressEvent);
       }.bind(this));
       stream.on('end', function() {
@@ -437,7 +446,7 @@
 
     proto.setRequestHeader = function setRequestHeader(header, value) {
       if (this.readyState === XMLHttpRequest.UNSENT) {
-        throw new Error(''); // todo  
+        throw new Error(''); // todo
       }
       this._properties.requestHeaders[header] = value;
     };


### PR DESCRIPTION
These lines add support to send progress datas (total, loaded and lengthComputable) with progress event.
