### PR TITLE
Fixed protocol relative URLS ("//hostname/path") and event properties

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -28,16 +28,87 @@ const constants = require('./constants');
 
 const OVERRIDE_PROTECTION_DESCRIPTOR = constants.OVERRIDE_PROTECTION_DESCRIPTOR;
 
+const eventConstants = {
+  NONE: {
+    configurable: false,
+    enumerable: true,
+    value: 0,
+    writable: false
+  },
+  CAPTURING_PHASE: {
+    configurable: false,
+    enumerable: true,
+    value: 1,
+    writable: false
+  },
+  AT_TARGET: {
+    configurable: false,
+    enumerable: true,
+    value: 2,
+    writable: false
+  },
+  BUBBLING_PHASE: {
+    configurable: false,
+    enumerable: true,
+    value: 3,
+    writable: false
+  }
+};
+
+const defaultDescriptor = {
+  configurable: false,
+  enumerable: true,
+  value: false,
+  writable: true
+};
+
+const _flagProps = {
+  canceled: defaultDescriptor,
+  dispatch: defaultDescriptor,
+  initialized: defaultDescriptor,
+  stopImmediatePropagation: defaultDescriptor,
+  stopPropagation: defaultDescriptor
+};
+
+const props = {
+  bubbles: OVERRIDE_PROTECTION_DESCRIPTOR,
+  cancelable: OVERRIDE_PROTECTION_DESCRIPTOR,
+  currentTarget: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    value: null
+  }),
+  eventPhase: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    value: eventConstants.NONE
+  }),
+  isTrusted: OVERRIDE_PROTECTION_DESCRIPTOR,
+  target: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    value: null
+  }),
+  timeStamp: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    value: 0
+  }),
+  type: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    value: ''
+  })
+};
+
 class Event {
   constructor(type) {
     if (arguments.length === 0) {
       throw new TypeError('Not enough arguments.');
     }
-    const timeStampDiscriptor = {};
-    Object.assign(timeStampDiscriptor, OVERRIDE_PROTECTION_DESCRIPTOR, {
+    const timeStampDescriptor = {};
+    Object.assign(timeStampDescriptor, OVERRIDE_PROTECTION_DESCRIPTOR, {
       value: Date.now()
     });
-    Object.defineProperty(this, 'timeStamp', timeStampDiscriptor);
+    Object.defineProperty(this, 'timeStamp', timeStampDescriptor);
+    Object.defineProperty(this, '_flag', {
+      configurable: false,
+      enumerable: false,
+      value: Object.create({}, _flagProps),
+      writable: false
+    });
+    Object.defineProperties(this, props);
+
     if (typeof type !== 'undefined') {
       this.initEvent(type);
     }
@@ -89,81 +160,7 @@ class Event {
 }
 
 (function() {
-  const eventConstants = {
-    NONE: {
-      configurable: false,
-      enumerable: true,
-      value: 0,
-      writable: false
-    },
-    CAPTURING_PHASE: {
-      configurable: false,
-      enumerable: true,
-      value: 1,
-      writable: false
-    },
-    AT_TARGET: {
-      configurable: false,
-      enumerable: true,
-      value: 2,
-      writable: false
-    },
-    BUBBLING_PHASE: {
-      configurable: false,
-      enumerable: true,
-      value: 3,
-      writable: false
-    }
-  };
-  const props = {
-    _flag: {
-      configurable: false,
-      enumerable: false,
-      value: Object.create(Object.prototype, (function() {
-        const defaultDiscriptor = {
-          configurable: false,
-          enumerable: true,
-          value: false,
-          writable: true
-        };
-        return {
-          canceled: Object.assign({}, defaultDiscriptor),
-          dispatch: Object.assign({}, defaultDiscriptor),
-          initialized: Object.assign({}, defaultDiscriptor),
-          stopImmediatePropagation: Object.assign({}, defaultDiscriptor),
-          stopPropagation: Object.assign({}, defaultDiscriptor)
-        };
-      })),
-      writable: false
-    },
-    bubbles: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: false
-    }),
-    cancelable: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: false
-    }),
-    currentTarget: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: null
-    }),
-    eventPhase: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: Event.NONE
-    }),
-    isTrusted: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: false
-    }),
-    target: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: null
-    }),
-    timeStamp: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: 0
-    }),
-    type: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: ''
-    })
-  };
   Object.defineProperties(Event, eventConstants);
-  Object.defineProperties(Event.prototype, Object.assign(
-    {}, eventConstants, props));
 })();
 
 module.exports = Event;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ utils.createClient = (function() {
 
   function optionsParse(options) {
     const newOptions = {};
-    const parsedUriObj = uriParse(options.uri || '');
+    const parsedUriObj = uriParse(options.uri || '', false, true);
     for (const key in defaultOptions) {
       if (defaultOptions.hasOwnProperty(key)) {
         const value = parsedUriObj[key];


### PR DESCRIPTION
Two commits...

- one fixes support for protocol relative URLs, right now they're being parsed incorrectly - realistically that's Node's fault for having silly default arguments.
- the other fixes an issue where every event instance was sharing the exact same property objects. This causes issues sending an event from the event handler of another event, among other issues.

With regard to the second fix, there's quite possibly other occurrences of the same bug through-out the library. Basically when you define properties on a prototype, you're defining them *on the prototype*, not the instances.

Unfortunately JS doesn't have a good way of defining properties for each instance (template/blueprint-like behaviour).