### PR TITLE
Adds support for ArrayBuffer, Uint8Array and Buffer to send(body)

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -339,7 +339,7 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       client.setHeader(key, value);
     });
     _readyStateChange.call(this, XMLHttpRequest.HEADERS_RECEIVED);
-    if ( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
+    if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
       body = Buffer.from(body);
     }
     if (typeof body === 'string' || body instanceof Buffer || body instanceof FormData) {

--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -339,8 +339,10 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       client.setHeader(key, value);
     });
     _readyStateChange.call(this, XMLHttpRequest.HEADERS_RECEIVED);
-    if (typeof body === 'string' || body instanceof FormData) {
-      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
+    if( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
+      body = Buffer.from(body);
+    }
+    if (typeof body === 'string' || body instanceof Buffer || body instanceof FormData) {      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
       client.write(body);
     }
     client.end();


### PR DESCRIPTION
XMLHttpRequet supports BufferSource as a send parameter, and this is used to transmit binary to the server as part of the POST method.

Node also supports transmitting binary in its HttpClient, which is the underlying implementation in w3c-xmlhttprequest. To utilise this you pass a Buffer into the client.write() method, but w3c-xmlhttprequest only writes String or FormData.

First we detect ArrayBuffer or Uint8Array as a body, and then convert to Buffer using Buffer.from(). Secondly, we modify the check to support Buffer as a valid body. This means that you can now use the XHR in-place of XMLHttpRequest when passing ArrayBuffer or Uint8Array.

Being able to use a Buffer as well in Node is a pleasant side-effect.

Possible improvements: Buffer.from() actually supports many more types, which could be used. Also, it is possible to convert typed-arrays to Buffer directly.