### PR TITLE
Make withCredentials writable

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -440,9 +440,10 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
     upload: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
       value: null
     }),
-    withCredentials: Object.assign({}, OVERRIDE_PROTECTION_DESCRIPTOR, {
-      value: false
-    })
+    withCredentials: {
+      value: false,
+      writable: true
+    }
   };
   Object.defineProperties(XMLHttpRequest, xmlHttpRequestConstants);
   Object.defineProperties(XMLHttpRequest.prototype, Object.assign(


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials `withCredentials` should be writable. 

I found the issue while running Jest test of a React Native project, which would fail with;
```
    TypeError: Cannot assign to read only property 'withCredentials' of object '#<XMLHttpRequest>'
        at node_modules/react-native/Libraries/vendor/core/whatwg-fetch.js:517:7
```

Fixes https://github.com/ykzts/node-xmlhttprequest/issues/39
