### PR TITLE
fix(release-please): support `require` under Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   "engines": {
     "node": ">= 10.13.0"
   },
-  "exports": "./dist/index.modern.js",
+  "exports": {
+    "import": "./dist/index.modern.js",
+    "require": "./dist/index.js"
+  },
   "files": [
     "dist",
     "types"


### PR DESCRIPTION
fixes #426

Solution from
https://github.com/GillianPerard/typescript-json-serializer/issues/129#issuecomment-803455774

This actually doesn't fix the repro case, but it fixes the issue if a `require()`d (`.js`, `.cjs`)) or `import`ed (`.mjs`) library depends on `w3c-xmlhttprequest`.